### PR TITLE
Implement ping and canPing methods for Openstack controller.

### DIFF
--- a/oscm-app-openstack-unittests/javasrc/org/oscm/app/openstack/OpenStackConnectionTest.java
+++ b/oscm-app-openstack-unittests/javasrc/org/oscm/app/openstack/OpenStackConnectionTest.java
@@ -31,12 +31,12 @@ import sun.net.www.protocol.http.HttpURLConnection;
  */
 public class OpenStackConnectionTest {
 
-    public static final String HTTPS_PROXY_HOST = "https.proxyHost";
-    public static final String HTTPS_PROXY_PORT = "https.proxyPort";
-    public static final String HTTP_NON_PROXY_HOSTS = "http.nonProxyHosts";
+    private static final String HTTPS_PROXY_HOST = "https.proxyHost";
+    private static final String HTTPS_PROXY_PORT = "https.proxyPort";
+    private static final String HTTP_NON_PROXY_HOSTS = "http.nonProxyHosts";
 
-    public static final String HTTPS_PROXY_USER = "https.proxyUser";
-    public static final String HTTPS_PROXY_PASSWORD = "https.proxyPassword";
+    private static final String HTTPS_PROXY_USER = "https.proxyUser";
+    private static final String HTTPS_PROXY_PASSWORD = "https.proxyPassword";
 
     @Before
     public void setUp() {
@@ -51,11 +51,11 @@ public class OpenStackConnectionTest {
         // when
         try {
             givenOpenStackConnetion().processRequest(url, "POST");
-            assertTrue("Test must fail with HeatException!", false);
+            fail("Test must fail with HeatException!");
         } catch (OpenStackConnectionException ex) {
             // then
-            assertTrue(ex.getMessage().indexOf("invalid URL") > -1);
-            assertTrue(ex.getMessage().indexOf(url) > -1);
+            assertTrue(ex.getMessage().contains("invalid URL"));
+            assertTrue(ex.getMessage().contains(url));
             assertEquals(-1, ex.getResponseCode());
         }
     }
@@ -79,12 +79,11 @@ public class OpenStackConnectionTest {
         // when
         try {
             givenOpenStackConnetion().processRequest(url, "POST");
-            assertTrue("Test must fail with HeatException!", false);
+            fail("Test must fail with HeatException!");
         } catch (OpenStackConnectionException ex) {
             // then
-            assertTrue(ex.getMessage()
-                    .indexOf("Expected http(s) connection for URL") > -1);
-            assertTrue(ex.getMessage().indexOf(url) > -1);
+            assertTrue(ex.getMessage().contains("Expected http(s) connection for URL"));
+            assertTrue(ex.getMessage().contains(url));
         }
     }
 
@@ -103,7 +102,7 @@ public class OpenStackConnectionTest {
                     }
 
                     @Override
-                    public int getResponseCode() throws IOException {
+                    public int getResponseCode() {
                         return 401;
                     }
 
@@ -122,14 +121,13 @@ public class OpenStackConnectionTest {
 
             oc.processRequest("http://openservicecatalogmanager.org", "POST");
 
-            assertTrue("Test must fail with HeatException!", false);
+            fail("Test must fail with HeatException!");
         } catch (OpenStackConnectionException ex) {
             // then
-            assertTrue(ex.getMessage().indexOf("unauthorized") > -1);
-            assertTrue(ex.getMessage().indexOf("HTTP 401") > -1);
-            assertTrue(ex.getMessage()
-                    .indexOf("http://openservicecatalogmanager.org") > -1);
-            assertTrue(ex.getMessage().indexOf("401 error occurred") > -1);
+            assertTrue(ex.getMessage().contains("unauthorized"));
+            assertTrue(ex.getMessage().contains("HTTP 401"));
+            assertTrue(ex.getMessage().contains("http://openservicecatalogmanager.org"));
+            assertTrue(ex.getMessage().contains("401 error occurred"));
         }
 
     }
@@ -148,7 +146,7 @@ public class OpenStackConnectionTest {
                     }
 
                     @Override
-                    public int getResponseCode() throws IOException {
+                    public int getResponseCode() {
                         return 400;
                     }
 
@@ -165,15 +163,13 @@ public class OpenStackConnectionTest {
         // when
         try {
             oc.processRequest("http://openservicecatalogmanager.org", "POST");
-            assertTrue("Test must fail with HeatException!", false);
+            fail("Test must fail with HeatException!");
         } catch (OpenStackConnectionException ex) {
             // then
-            assertTrue(ex.getMessage()
-                    .indexOf("either input parameter format error") > -1);
-            assertTrue(ex.getMessage().indexOf("HTTP 400") > -1);
-            assertTrue(ex.getMessage()
-                    .indexOf("http://openservicecatalogmanager.org") > -1);
-            assertTrue(ex.getMessage().indexOf("400 error occurred") > -1);
+            assertTrue(ex.getMessage().contains("either input parameter format error"));
+            assertTrue(ex.getMessage().contains("HTTP 400"));
+            assertTrue(ex.getMessage().contains("http://openservicecatalogmanager.org"));
+            assertTrue(ex.getMessage().contains("400 error occurred"));
         }
     }
 
@@ -191,7 +187,7 @@ public class OpenStackConnectionTest {
                     }
 
                     @Override
-                    public int getResponseCode() throws IOException {
+                    public int getResponseCode() {
                         return 404;
                     }
 
@@ -208,14 +204,13 @@ public class OpenStackConnectionTest {
         // when
         try {
             oc.processRequest("http://openservicecatalogmanager.org", "POST");
-            assertTrue("Test must fail with HeatException!", false);
+            fail("Test must fail with HeatException!");
         } catch (OpenStackConnectionException ex) {
             // then
-            assertTrue(ex.getMessage().indexOf("resource not found") > -1);
-            assertTrue(ex.getMessage().indexOf("HTTP 404") > -1);
-            assertTrue(ex.getMessage()
-                    .indexOf("http://openservicecatalogmanager.org") > -1);
-            assertTrue(ex.getMessage().indexOf("404 error occurred") > -1);
+            assertTrue(ex.getMessage().contains("resource not found"));
+            assertTrue(ex.getMessage().contains("HTTP 404"));
+            assertTrue(ex.getMessage().contains("http://openservicecatalogmanager.org"));
+            assertTrue(ex.getMessage().contains("404 error occurred"));
         }
     }
 
@@ -234,13 +229,12 @@ public class OpenStackConnectionTest {
                     }
 
                     @Override
-                    public int getResponseCode() throws IOException {
+                    public int getResponseCode() {
                         return 406;
                     }
 
                     @Override
-                    public synchronized InputStream getInputStream()
-                            throws IOException {
+                    public synchronized InputStream getInputStream() {
                         return new ByteArrayInputStream(
                                 "exception test".getBytes());
                     }
@@ -258,15 +252,14 @@ public class OpenStackConnectionTest {
         // when
         try {
             oc.processRequest("http://openservicecatalogmanager.org", "POST");
-            assertTrue("Test must fail with HeatException!", false);
+            fail("Test must fail with HeatException!");
         } catch (OpenStackConnectionException ex) {
             // then
-            assertTrue(ex.getMessage().indexOf("send failed") > -1);
-            assertTrue(ex.getMessage().indexOf("HTTP 406") > -1);
-            assertTrue(ex.getMessage()
-                    .indexOf("http://openservicecatalogmanager.org") > -1);
-            assertTrue(ex.getMessage().indexOf("406 error occurred") > -1);
-            assertTrue(ex.getMessage().indexOf(msg) > -1);
+            assertTrue(ex.getMessage().contains("send failed"));
+            assertTrue(ex.getMessage().contains("HTTP 406"));
+            assertTrue(ex.getMessage().contains("http://openservicecatalogmanager.org"));
+            assertTrue(ex.getMessage().contains("406 error occurred"));
+            assertTrue(ex.getMessage().contains(msg));
         }
     }
 
@@ -284,7 +277,7 @@ public class OpenStackConnectionTest {
                     }
 
                     @Override
-                    public int getResponseCode() throws IOException {
+                    public int getResponseCode() {
                         return 504;
                     }
 
@@ -301,14 +294,13 @@ public class OpenStackConnectionTest {
         // when
         try {
             oc.processRequest("http://openservicecatalogmanager.org", "POST");
-            assertTrue("Test must fail with HeatException!", false);
+            fail("Test must fail with HeatException!");
         } catch (OpenStackConnectionException ex) {
             // then
-            assertTrue(ex.getMessage().indexOf("Gateway/proxy timeout") > -1);
-            assertTrue(ex.getMessage().indexOf("HTTP 504") > -1);
-            assertTrue(ex.getMessage()
-                    .indexOf("http://openservicecatalogmanager.org") > -1);
-            assertTrue(ex.getMessage().indexOf("504 error occurred") > -1);
+            assertTrue(ex.getMessage().contains("Gateway/proxy timeout"));
+            assertTrue(ex.getMessage().contains("HTTP 504"));
+            assertTrue(ex.getMessage().contains("http://openservicecatalogmanager.org"));
+            assertTrue(ex.getMessage().contains("504 error occurred"));
         }
     }
 
@@ -333,11 +325,11 @@ public class OpenStackConnectionTest {
         try {
             givenOpenStackConnetion().processRequest(
                     "http://openservicecatalogmanager.org", "POST");
-            assertTrue("Test must fail with HeatException!", false);
+            fail("Test must fail with HeatException!");
         } catch (OpenStackConnectionException ex) {
             // then
-            assertTrue(ex.getMessage().indexOf("send failed") > -1);
-            assertTrue(ex.getMessage().indexOf(msg) > -1);
+            assertTrue(ex.getMessage().contains("send failed"));
+            assertTrue(ex.getMessage().contains(msg));
         }
     }
 
@@ -357,17 +349,17 @@ public class OpenStackConnectionTest {
                     throws IOException {
                 return new HttpURLConnection(u, p) {
                     @Override
-                    public void connect() throws IOException {
+                    public void connect() {
                         assertTrue("Connect successful", true);
                     }
 
                     @Override
-                    public int getResponseCode() throws IOException {
+                    public int getResponseCode() {
                         return 200;
                     }
 
                     @Override
-                    public InputStream getInputStream() throws IOException {
+                    public InputStream getInputStream() {
                         connect();
                         return new ByteArrayInputStream(
                                 "connect success".getBytes());
@@ -608,9 +600,7 @@ public class OpenStackConnectionTest {
                     public int getResponseCode() throws IOException {
                         return -1;
                     }
-
                 };
-
             }
         };
         OpenStackConnection.setURLStreamHandler(st);
@@ -622,19 +612,17 @@ public class OpenStackConnectionTest {
             fail("Test must fail with Exception!");
         } catch (OpenStackConnectionException ex) {
             // then
-            assertTrue(ex.getMessage(), ex.getMessage().indexOf("send failed") > -1);
+            assertTrue(ex.getMessage(), ex.getMessage().contains("send failed"));
         }
     }
 
-    OpenStackConnection givenOpenStackConnetion() {
+    private OpenStackConnection givenOpenStackConnetion() {
         return new OpenStackConnection("some test") {
 
             @Override
             protected Proxy resolveProxy(String proxyHost, int proxyPortInt) {
                 return Proxy.NO_PROXY;
             }
-
         };
     }
-
 }

--- a/oscm-app-openstack/.classpath
+++ b/oscm-app-openstack/.classpath
@@ -18,5 +18,6 @@
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="lib" path="/libraries/openstack4j/javalib/openstack4j-3.1.0.jar"/>
 	<classpathentry kind="lib" path="/oscm-build/lib/guava-18.0.jar"/>
+	<classpathentry kind="lib" path="/libraries/apache-tomee/javalib/javax.faces-2.2.12.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/oscm-app-openstack/javasrc/org/oscm/app/openstack/OpenStackConnection.java
+++ b/oscm-app-openstack/javasrc/org/oscm/app/openstack/OpenStackConnection.java
@@ -8,28 +8,21 @@
 
 package org.oscm.app.openstack;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.net.Authenticator;
-import java.net.HttpURLConnection;
-import java.net.InetSocketAddress;
-import java.net.MalformedURLException;
-import java.net.Proxy;
-import java.net.URL;
-import java.net.URLStreamHandler;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
-
-import javax.net.ssl.HttpsURLConnection;
-import javax.net.ssl.SSLContext;
-
 import org.oscm.app.openstack.exceptions.OpenStackConnectionException;
 import org.oscm.app.openstack.proxy.ProxyAuthenticator;
 import org.oscm.app.openstack.proxy.ProxySettings;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.*;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 
 /**
  * A connection to the OpenStack Heat API.
@@ -137,7 +130,7 @@ public class OpenStackConnection {
             // add payload if present
             if (requestBody != null) {
                 if (!requestBody.contains("password")) {
-                    logger.debug("   request body:\n" + requestBody);
+                    logger.debug("Request body:\n" + requestBody);
                 }
                 connection.setRequestProperty("Content-Type",
                         "application/json");
@@ -149,7 +142,7 @@ public class OpenStackConnection {
             connection.connect();
             return new RESTResponse(connection);
         } catch (MalformedURLException e) {
-            throw new OpenStackConnectionException("invalid URL: " + restUri);
+            throw new OpenStackConnectionException("Invalid URL: " + restUri);
         } catch (IOException e) {
             int responseCode = -1;
             String responseBody = "";
@@ -161,25 +154,23 @@ public class OpenStackConnection {
                     + ", responseBody " + responseBody + "): " + e.getMessage();
             switch (responseCode) {
             case 400:
-                throw new OpenStackConnectionException(
-                        "either input parameter format error or security key is not correct"
-                                + code,
-                        responseCode);
+                throw new OpenStackConnectionException("Either input parameter format error " +
+                        "or security key is not correct. " + code, responseCode);
             case 401:
-                throw new OpenStackConnectionException("unauthorized" + code,
-                        responseCode);
+                throw new OpenStackConnectionException(
+                        "Unauthorized. " + code, responseCode);
 
             case 404:
                 throw new OpenStackConnectionException(
-                        "resource not found" + code, responseCode);
+                        "Resource not found. " + code, responseCode);
 
             case 504:
                 throw new OpenStackConnectionException(
-                        " Gateway/proxy timeout." + code, responseCode);
+                        "Gateway/proxy timeout. " + code, responseCode);
 
             default:
-                throw new OpenStackConnectionException("send failed" + code,
-                        responseCode);
+                throw new OpenStackConnectionException(
+                        "Send failed. " + code, responseCode);
             }
         } finally {
             if (out != null) {
@@ -250,12 +241,10 @@ public class OpenStackConnection {
         URL url = new URL(null, restUri, streamHandler);
 
         try {
-
             if (ProxySettings.useProxyByPass(url)) {
                 connection = (HttpURLConnection) url
                         .openConnection(Proxy.NO_PROXY);
             } else {
-
                 String proxyHost = System
                         .getProperty(ProxySettings.HTTPS_PROXY_HOST);
                 String proxyPort = System
@@ -274,16 +263,13 @@ public class OpenStackConnection {
                 }
                 if (proxyHost != null && proxyPortInt > 0) {
                     Proxy proxy = resolveProxy(proxyHost, proxyPortInt);
-
                     if (proxyUser != null && proxyUser.length() > 0
                             && proxyPassword != null
                             && proxyPassword.length() > 0) {
 
                         Authenticator.setDefault(new ProxyAuthenticator(
                                 proxyUser, proxyPassword));
-
                     }
-
                     connection = openConnection(url, proxy);
                 }
 

--- a/oscm-app-openstack/javasrc/org/oscm/app/openstack/controller/OpenStackController.java
+++ b/oscm-app-openstack/javasrc/org/oscm/app/openstack/controller/OpenStackController.java
@@ -19,6 +19,7 @@ import static org.oscm.app.openstack.data.FlowState.DELETION_REQUESTED;
 import static org.oscm.app.openstack.data.FlowState.MODIFICATION_REQUESTED;
 import static org.oscm.app.openstack.data.FlowState.UPDATE_PROJECT;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
@@ -28,22 +29,19 @@ import javax.ejb.Remote;
 import javax.ejb.Stateless;
 import javax.ejb.TransactionAttribute;
 import javax.ejb.TransactionAttributeType;
+import javax.faces.context.FacesContext;
+import javax.inject.Inject;
+import javax.servlet.http.HttpSession;
 
+import org.oscm.app.openstack.KeystoneClient;
 import org.oscm.app.openstack.NovaProcessor;
+import org.oscm.app.openstack.OpenStackConnection;
 import org.oscm.app.openstack.data.FlowState;
+import org.oscm.app.openstack.exceptions.OpenStackConnectionException;
 import org.oscm.app.openstack.i18n.Messages;
 import org.oscm.app.openstack.usage.UsageConverter;
 import org.oscm.app.v2_0.APPlatformServiceFactory;
-import org.oscm.app.v2_0.data.Context;
-import org.oscm.app.v2_0.data.ControllerSettings;
-import org.oscm.app.v2_0.data.InstanceDescription;
-import org.oscm.app.v2_0.data.InstanceStatus;
-import org.oscm.app.v2_0.data.InstanceStatusUsers;
-import org.oscm.app.v2_0.data.LocalizedText;
-import org.oscm.app.v2_0.data.OperationParameter;
-import org.oscm.app.v2_0.data.ProvisioningSettings;
-import org.oscm.app.v2_0.data.ServiceUser;
-import org.oscm.app.v2_0.data.Setting;
+import org.oscm.app.v2_0.data.*;
 import org.oscm.app.v2_0.exceptions.APPlatformException;
 import org.oscm.app.v2_0.exceptions.LogAndExceptionConverter;
 import org.oscm.app.v2_0.intf.APPlatformController;
@@ -80,6 +78,8 @@ public class OpenStackController extends ProvisioningValidator
 
     private static final int SERVERS_NUMBER_CANNOT_BE_CHECKED = 0;
 
+    @Inject
+    private OpenStackControllerAccess controllerAccess;
     private APPlatformService platformService;
 
     /**
@@ -606,5 +606,66 @@ public class OpenStackController extends ProvisioningValidator
             }
         }
         return false;
+    }
+
+    @Override
+    public boolean ping(String controllerId) {
+        HashMap<String, Setting> settings;
+        try {
+            settings = getControllerSettings();
+        } catch (APPlatformException e) {
+            LOGGER.error("Failed to get controller settings. ", e);
+            return false;
+        }
+        OpenStackConnection connection = new OpenStackConnection(
+                settings.get("KEYSTONE_API_URL").getValue());
+        KeystoneClient client = new KeystoneClient(connection);
+        try {
+            client.authenticate(settings.get("API_USER_NAME").getValue(),
+                    settings.get("API_USER_PWD").getValue(),
+                    settings.get("DOMAIN_NAME").getValue(),
+                    settings.get("TENANT_ID").getValue());
+            LOGGER.info("Verification of connection to Openstack successful. " +
+                    "Keystone API URL: " + settings.get("KEYSTONE_API_URL").getValue());
+            return true;
+        } catch (OpenStackConnectionException | APPlatformException e) {
+            LOGGER.error("Exception caught while trying to ping controller! " + e);
+            return false;
+        }
+    }
+
+    @Override
+    public boolean canPing() {
+        HashMap<String, Setting> settings;
+        try {
+            settings = getControllerSettings();
+        } catch (APPlatformException e) {
+            LOGGER.error("Failed to get controller settings. ", e);
+            return false;
+        }
+        String keystoneApiUrl = settings.get("KEYSTONE_API_URL").getValue();
+        String apiUserName = settings.get("API_USER_NAME").getValue();
+        String apiUserPassword = settings.get("API_USER_PWD").getValue();
+        String domainName = settings.get("DOMAIN_NAME").getValue();
+        String tenantId = settings.get("TENANT_ID").getValue();
+        return !keystoneApiUrl.equals("") && !apiUserName.equals("") &&
+                !apiUserPassword.equals("") && !domainName.equals("") && !tenantId.equals("");
+    }
+
+    private HashMap<String, Setting> getControllerSettings() throws APPlatformException {
+        FacesContext facesContext = FacesContext.getCurrentInstance();
+        HttpSession session = (HttpSession) facesContext
+                .getExternalContext().getSession(false);
+        String username = "" + session.getAttribute("loggedInUserId");
+        String password = "" + session.getAttribute("loggedInUserPassword");
+        HashMap<String, Setting> settings;
+        try {
+            settings = platformService.getControllerSettings(
+                    controllerAccess.getControllerId(),
+                    new PasswordAuthentication(username, password));
+            return settings;
+        } catch (APPlatformException e) {
+            throw new APPlatformException("Failed to get controller settings.");
+        }
     }
 }

--- a/oscm-app-openstack/javasrc/org/oscm/app/openstack/controller/OpenStackController.java
+++ b/oscm-app-openstack/javasrc/org/oscm/app/openstack/controller/OpenStackController.java
@@ -43,7 +43,9 @@ import org.oscm.app.openstack.usage.UsageConverter;
 import org.oscm.app.v2_0.APPlatformServiceFactory;
 import org.oscm.app.v2_0.data.*;
 import org.oscm.app.v2_0.exceptions.APPlatformException;
+import org.oscm.app.v2_0.exceptions.ConfigurationException;
 import org.oscm.app.v2_0.exceptions.LogAndExceptionConverter;
+import org.oscm.app.v2_0.exceptions.ServiceNotReachableException;
 import org.oscm.app.v2_0.intf.APPlatformController;
 import org.oscm.app.v2_0.intf.APPlatformService;
 import org.slf4j.Logger;
@@ -609,63 +611,12 @@ public class OpenStackController extends ProvisioningValidator
     }
 
     @Override
-    public boolean ping(String controllerId) {
-        HashMap<String, Setting> settings;
-        try {
-            settings = getControllerSettings();
-        } catch (APPlatformException e) {
-            LOGGER.error("Failed to get controller settings. ", e);
-            return false;
-        }
-        OpenStackConnection connection = new OpenStackConnection(
-                settings.get("KEYSTONE_API_URL").getValue());
-        KeystoneClient client = new KeystoneClient(connection);
-        try {
-            client.authenticate(settings.get("API_USER_NAME").getValue(),
-                    settings.get("API_USER_PWD").getValue(),
-                    settings.get("DOMAIN_NAME").getValue(),
-                    settings.get("TENANT_ID").getValue());
-            LOGGER.info("Verification of connection to Openstack successful. " +
-                    "Keystone API URL: " + settings.get("KEYSTONE_API_URL").getValue());
-            return true;
-        } catch (OpenStackConnectionException | APPlatformException e) {
-            LOGGER.error("Exception caught while trying to ping controller! " + e);
-            return false;
-        }
+    public boolean ping(String controllerId) throws ServiceNotReachableException {
+        return true;
     }
 
     @Override
-    public boolean canPing() {
-        HashMap<String, Setting> settings;
-        try {
-            settings = getControllerSettings();
-        } catch (APPlatformException e) {
-            LOGGER.error("Failed to get controller settings. ", e);
-            return false;
-        }
-        String keystoneApiUrl = settings.get("KEYSTONE_API_URL").getValue();
-        String apiUserName = settings.get("API_USER_NAME").getValue();
-        String apiUserPassword = settings.get("API_USER_PWD").getValue();
-        String domainName = settings.get("DOMAIN_NAME").getValue();
-        String tenantId = settings.get("TENANT_ID").getValue();
-        return !keystoneApiUrl.equals("") && !apiUserName.equals("") &&
-                !apiUserPassword.equals("") && !domainName.equals("") && !tenantId.equals("");
-    }
-
-    private HashMap<String, Setting> getControllerSettings() throws APPlatformException {
-        FacesContext facesContext = FacesContext.getCurrentInstance();
-        HttpSession session = (HttpSession) facesContext
-                .getExternalContext().getSession(false);
-        String username = "" + session.getAttribute("loggedInUserId");
-        String password = "" + session.getAttribute("loggedInUserPassword");
-        HashMap<String, Setting> settings;
-        try {
-            settings = platformService.getControllerSettings(
-                    controllerAccess.getControllerId(),
-                    new PasswordAuthentication(username, password));
-            return settings;
-        } catch (APPlatformException e) {
-            throw new APPlatformException("Failed to get controller settings.");
-        }
+    public boolean canPing() throws ConfigurationException {
+        return true;
     }
 }

--- a/oscm-common/javasrc/org/oscm/types/constants/Configuration.java
+++ b/oscm-common/javasrc/org/oscm/types/constants/Configuration.java
@@ -42,6 +42,7 @@ public interface Configuration {
          */
         public static final List<String> pingableControllersList = Arrays
                 .asList(
-                        VMWARE_CONTROLLER_ID
+                        VMWARE_CONTROLLER_ID,
+                        OPENSTACK_CONTROLLER_ID
                 );
 }


### PR DESCRIPTION
Keep in mind that OpenStack address might need to be added to nonProxyHosts.

Here is an example configuration for the controller: 
**Notice the /auth after keystone v3 api url!**
htpps://<oscm-ip>/oscm-app-openstack/index.xhtml

![obraz](https://user-images.githubusercontent.com/19170783/53880521-7c90d900-4011-11e9-8164-de8625087d6a.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm/236)
<!-- Reviewable:end -->
