### PR TITLE
Add missing japan bundle in VMware Messages class

### DIFF
--- a/oscm-app-vmware/javasrc/org/oscm/app/vmware/i18n/Messages.java
+++ b/oscm-app-vmware/javasrc/org/oscm/app/vmware/i18n/Messages.java
@@ -43,6 +43,8 @@ public class Messages {
                 ResourceBundle.getBundle(BUNDLE_NAME, new Locale("en")));
         bundleList.put("de",
                 ResourceBundle.getBundle(BUNDLE_NAME, new Locale("de")));
+        bundleList.put("ja",
+                ResourceBundle.getBundle(BUNDLE_NAME, new Locale("ja")));
     };
 
     private Messages() {


### PR DESCRIPTION
As the tittle says.
In other controllers this bundle is not missing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm/275)
<!-- Reviewable:end -->
