### PR TITLE
Enclose iframe for branded stage inside a div for responsive container.

### DIFF
--- a/oscm-portal/javasrc/org/oscm/ui/beans/SkinBean.java
+++ b/oscm-portal/javasrc/org/oscm/ui/beans/SkinBean.java
@@ -40,6 +40,9 @@ public class SkinBean extends BaseBean implements Serializable {
       "<img class=\"img-fluid\" id=\"marketplaceStageDefault\" src=\"{0}"
           + Marketplace.MARKETPLACE_ROOT
           + "/img/flash.png\" style=\"border-style: none;\" />";
+  
+  public static final String MARKETPLACE_STAGE_BRANDED =
+          "<div class=\"responsive-container\">{0}</div>";
 
   public static final String MARKETPLACE_MOBILE_STAGE_DEFAULT =
       "<img class=\"img-fluid\" id=\"marketplaceMobileStageDefault\" src=\"{0}"
@@ -143,18 +146,11 @@ public class SkinBean extends BaseBean implements Serializable {
       // No localized resource found for the mpl stage
       marketplaceStage = MessageFormat.format(MARKETPLACE_STAGE_DEFAULT, getRequestContextPath());
     } else {
-      marketplaceStage = appendResponsiveDiv(marketplaceStage);
+      marketplaceStage = MessageFormat.format(MARKETPLACE_STAGE_BRANDED, marketplaceStage);
     }
     return marketplaceStage;
   }
 
-  private String appendResponsiveDiv(String mpStage) {
-    StringBuilder brandedStageBuilder = new StringBuilder();
-    brandedStageBuilder.append("<div class=\"responsive-container\">");
-    brandedStageBuilder.append(mpStage);
-    brandedStageBuilder.append("</div>");
-    return brandedStageBuilder.toString();
-  }
   /**
    * Retrieves the content of the mpl mobile stage from the brand service. If there was no localized
    * resource defined for the mobile stage content, a default will be returned. The locale used to

--- a/oscm-portal/javasrc/org/oscm/ui/beans/SkinBean.java
+++ b/oscm-portal/javasrc/org/oscm/ui/beans/SkinBean.java
@@ -142,10 +142,19 @@ public class SkinBean extends BaseBean implements Serializable {
     if (isEmpty(marketplaceStage)) {
       // No localized resource found for the mpl stage
       marketplaceStage = MessageFormat.format(MARKETPLACE_STAGE_DEFAULT, getRequestContextPath());
+    } else {
+      marketplaceStage = appendResponsiveDiv(marketplaceStage);
     }
     return marketplaceStage;
   }
 
+  private String appendResponsiveDiv(String mpStage) {
+    StringBuilder brandedStageBuilder = new StringBuilder();
+    brandedStageBuilder.append("<div class=\"responsive-container\">");
+    brandedStageBuilder.append(mpStage);
+    brandedStageBuilder.append("</div>");
+    return brandedStageBuilder.toString();
+  }
   /**
    * Retrieves the content of the mpl mobile stage from the brand service. If there was no localized
    * resource defined for the mobile stage content, a default will be returned. The locale used to


### PR DESCRIPTION
**Changes in this Pull Request:**
- The iframe for the branded stage must be enclosed the <div class="responsive-container"> in order to work.

**Mandatory checks:**
- [X] Branch is up to date (latest changes were fetched from the upstream branch before creating this PR)
- [X] Changes were tested manually
- [ ] Java code changes are unit tested
- [ ] Webtests are successful

**To be checked by the reviewer:**
- [ ] Clean Java code and unit tested changes 
- [ ] UI customizablity is preserved: No hard-coded styling and URL references in JSF views 

**To be checked by the pull request owner:**
- [ ] .MASTER/job/BES_MASTER_IT/
- [ ] .MASTER/job/OSCM_WS_Tests_INTERNAL/
- [ ] .MASTER/job/OSCM_WS_Tests_OIDC/
- [ ] .MASTER/job/OSCM_Integration_Tests_INTERNAL/
- [ ] .MASTER/job/OSCM_Integration_Tests_OIDC/

**Cross repository and core changes:**
- [ ] Interdependent changes have been communicated to the team (if applicable)
- [ ] This pull request includes high risk modifications or core changes (e.g API, datamodel, authentication...). Mandatory reviewers: @goebell or @kowalczyka.

**OSCM Build References:**
- &lt;CI node number&gt;: &lt;tag&gt;, _example_: ci10:goebell

**Screenshot (if applicable):**
- add a screenshot illustrating your change

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm/1013)
<!-- Reviewable:end -->
