### PR TITLE
Fix #1205 - move rgb() to CSS var definition.

### DIFF
--- a/oscm-portal/WebContent/marketplace/customBootstrap/scss/_customVariables.scss
+++ b/oscm-portal/WebContent/marketplace/customBootstrap/scss/_customVariables.scss
@@ -76,7 +76,7 @@ $darkened-color:                       rgb(var(--oscm-primary));
 
  // Text color for Account Menu header.
  #link0 {
-   color:                              rgb(var(--oscm-navbar-links-color));
+   color:                              var(--oscm-navbar-links-color);
 
    &:hover  {
      color:                            $navbar-dark-hover-color;
@@ -206,7 +206,7 @@ hr {
 }
 
 .bg-themed-navigation {
-  background-color:                    rgb(var(--oscm-navbar-color));
+  background-color:                    var(--oscm-navbar-color);
 }
 
 .editPen { 

--- a/oscm-portal/WebContent/marketplace/customBootstrap/scss/basic/_colors.scss
+++ b/oscm-portal/WebContent/marketplace/customBootstrap/scss/basic/_colors.scss
@@ -4,8 +4,8 @@
 
  --oscm-main-input-color:              248, 248, 248;
  --oscm-main-font-color:               33, 33, 33;
- --oscm-navbar-color:                  28, 28, 28;
- --oscm-navbar-links-color:            217, 218, 219;
+ --oscm-navbar-color:                  rgb(28, 28, 28);
+ --oscm-navbar-links-color:            rgb(217, 218, 219);
 
  --oscm-white:                         255, 255, 255;
  --oscm-black:                         0, 0, 0;
@@ -42,8 +42,8 @@
 
  --oscm-main-font-color:               248, 248, 248;
  --oscm-main-input-color:              33, 33, 33;
- --oscm-navbar-color:                  28, 28, 28;
- --oscm-navbar-links-color:            217, 218, 219;
+ --oscm-navbar-color:                  rgb(28, 28, 28);
+ --oscm-navbar-links-color:            rgb(217, 218, 219);
 
  --oscm-white:                         255, 255, 255;
  --oscm-black:                         0, 0, 0;
@@ -82,8 +82,8 @@
 
    --oscm-main-font-color:             248, 248, 248;
    --oscm-main-input-color:            33, 33, 33;
-   --oscm-navbar-color:                28, 28, 28;
-   --oscm-navbar-links-color:          217, 218, 219;
+   --oscm-navbar-color:                rgb(28, 28, 28);
+   --oscm-navbar-links-color:          rgb(217, 218, 219);
 
    --oscm-white:                       255, 255, 255;
    --oscm-black:                       0, 0, 0;

--- a/oscm-portal/WebContent/marketplace/customBootstrap/scss/components/_navbar.scss
+++ b/oscm-portal/WebContent/marketplace/customBootstrap/scss/components/_navbar.scss
@@ -65,7 +65,7 @@
 }
 
 .navbar-toggler-icon {
-  color: rgb(var(--oscm-navbar-links-color));
+  color: var(--oscm-navbar-links-color);
   font-size: 1.8rem;
   height: auto;
   padding: 0.2rem;

--- a/oscm-portal/WebContent/marketplace/customBootstrap/scss/components/_navbar.scss
+++ b/oscm-portal/WebContent/marketplace/customBootstrap/scss/components/_navbar.scss
@@ -56,11 +56,11 @@
 }
 
 .nav-link {
-  color: rgb(var(--oscm-navbar-links-color));
+  color: var(--oscm-navbar-links-color);
 }
 
 .navbar-toggler {
-  border: 1px solid rgb(var(--oscm-navbar-links-color));
+  border: 1px solid var(--oscm-navbar-links-color);
   padding: 0px;
 }
 

--- a/oscm-portal/WebContent/marketplace/customBootstrap/scss/components/_navbar.scss
+++ b/oscm-portal/WebContent/marketplace/customBootstrap/scss/components/_navbar.scss
@@ -51,8 +51,8 @@
 }
 
 .navbar-themed {
-  background-color: rgb(var(--oscm-navbar-color)) !important;
-  color: rgb(var(--oscm-navbar-links-color));
+  background-color: var(--oscm-navbar-color) !important;
+  color: var(--oscm-navbar-links-color);
 }
 
 .nav-link {

--- a/oscm-portal/WebContent/marketplace/customBootstrap/scss/customFooter.scss
+++ b/oscm-portal/WebContent/marketplace/customBootstrap/scss/customFooter.scss
@@ -5,9 +5,9 @@
 
 @import "myvariables";
 
-$toggled-background: rgb(var(--oscm-navbar-color));
+$toggled-background: var(--oscm-navbar-color);
 
-$footer-link-color: rgb(var(--oscm-navbar-links-color));
+$footer-link-color: var(--oscm-navbar-links-color);
 
 .bootstrap_footer {
 	background: $toggled-background;


### PR DESCRIPTION
**Changes in this Pull Request:**
- Moved rgb() function to variable definition.
- In the Backend the following values must be set if light navigation bar is desired:
   --oscm-navbar-color: rgba(var(--oscm-white), 0.8);
   --oscm-navbar-links-color: rgb(var(--oscm-primary));


**Mandatory checks:**
- [X] Branch is up to date (latest changes were fetched from the upstream branch before creating this PR)
- [X] Changes were tested manually
- [ ] Java code changes are unit tested
- [ ] Webtests are successful

**To be checked by the reviewer:**
- [ ] Clean Java code and unit tested changes 
- [ ] UI customizablity is preserved: No hard-coded styling and URL references in JSF views 

**To be checked by the pull request owner:**
- [ ] .MASTER/job/BES_MASTER_IT/
- [ ] .MASTER/job/OSCM_WS_Tests_INTERNAL/
- [ ] .MASTER/job/OSCM_WS_Tests_OIDC/
- [ ] .MASTER/job/OSCM_Integration_Tests_INTERNAL/
- [ ] .MASTER/job/OSCM_Integration_Tests_OIDC/

**Cross repository and core changes:**
- [ ] Interdependent changes have been communicated to the team (if applicable)
- [ ] This pull request includes high risk modifications or core changes (e.g API, datamodel, authentication...). Mandatory reviewers: @goebell or @kowalczyka.

**OSCM Build References:**
- &lt;CI node number&gt;: &lt;tag&gt;, _example_: ci10:goebell
-est6

**Screenshot (if applicable):**
- add a screenshot illustrating your change

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm/1212)
<!-- Reviewable:end -->
