### PR TITLE
Task#1207 use of hsl instead of rgb

### DIFF
--- a/oscm-portal/WebContent/marketplace/customBootstrap/scss/_customVariables.scss
+++ b/oscm-portal/WebContent/marketplace/customBootstrap/scss/_customVariables.scss
@@ -36,7 +36,7 @@ $modal_dialog_text_color:              var(--oscm-rv-color);
 
 // Tables
 $table-bg:                             var(--oscm-main-color-700);
-$theme-table-hover-color:              var(rgba(var(--oscm-main), 0.3));
+$theme-table-hover-color:              var(hsla(var(--oscm-main), 0.3));
 $theme-table-bg-color:                 var(--oscm-table-bg-color);
 $theme-table-odd-color:                var(--oscm-table-row-odd-color);
 $theme-table-even-color:               var(--oscm-table-row-even-color);

--- a/oscm-portal/WebContent/marketplace/customBootstrap/scss/_customVariables.scss
+++ b/oscm-portal/WebContent/marketplace/customBootstrap/scss/_customVariables.scss
@@ -6,26 +6,26 @@ $bg-light:                             var(--body-bg);
 $custom-select-bg:                     var(--oscm-main-color-800);
 
 $breadcrumb-bg:                        var(--oscm-main-color-500);
-$breadcrumb-active-color:              rgb(var(--oscm-primary));
+$breadcrumb-active-color:              hsl(var(--oscm-primary));
 
 // Dropdowns
 $dropdown-bg:                          var(--oscm-dropdown-color);
 $dropdown-divider-bg:                  var(--oscm-border-color);
 $dropdown-link-color:                  var(--oscm-text-color);
 $dropdown-color:                       var(--oscm-text-color);
-$dropdown-link-active-bg:              rgb(var(--oscm-primary));
-$dropdown-link-hover-bg:               rgb(var(--oscm-primary));
+$dropdown-link-active-bg:              hsl(var(--oscm-primary));
+$dropdown-link-hover-bg:               hsl(var(--oscm-primary));
 $dropdown-link-hover-color:            rgb(var(--oscm-white));
 
 // Colors for list groups only for dark theme
 $list-group-bg:                        var(--oscm-main-color-800);
 $list-group-border-color:              var(--oscm-border-color);
 $list-group-disabled-bg:               var(--oscm-main-color-700);
-$list-group-hover-bg:                  rgb(var(--oscm-primary));
-$list-group-action-active-bg:          rgb(var(--oscm-primary));
+$list-group-hover-bg:                  hsl(var(--oscm-primary));
+$list-group-action-active-bg:          hsl(var(--oscm-primary));
 
-$link-color:                           rgb(var(--oscm-primary));
-$link-hover-color:                     rgb(var(--oscm-primary));
+$link-color:                           hsl(var(--oscm-primary));
+$link-hover-color:                     hsl(var(--oscm-primary));
 
 // Popovers
 $popover-bg:                           var(--oscm-input-color);
@@ -47,13 +47,13 @@ $theme-table-border-bottom-color:      var(--oscm-main-color-700);
 $input-bg:                             var(--oscm-main-color-800);
 $input-focus-bg:                       var(--oscm-main-color-800);
 $input-focus-color:                    var(--oscm-rv-color);
-$input-focus-border-color:             rgb(var(--oscm-primary));
-$input-group-addon-border-color:       rgb(var(--oscm-primary));
+$input-focus-border-color:             hsl(var(--oscm-primary));
+$input-group-addon-border-color:       hsl(var(--oscm-primary));
 
-$lightened-color:                      rgba(var(--oscm-primary), 0.5);
+$lightened-color:                      hsla(var(--oscm-primary), 0.5);
 
-$hover-color:                          rgb(var(--oscm-primary));
-$darkened-color:                       rgb(var(--oscm-primary));
+$hover-color:                          hsl(var(--oscm-primary));
+$darkened-color:                       hsl(var(--oscm-primary));
 
 .list-group-item {
   color:                               rgb(var(--oscm-text-color));
@@ -84,74 +84,74 @@ $darkened-color:                       rgb(var(--oscm-primary));
  }
 
 .btn-primary, .btn-secondary {
-  background-color:                    rgb(var(--oscm-primary)) !important;
-  border-color:                        rgb(var(--oscm-primary)) !important;
+  background-color:                    hsl(var(--oscm-primary)) !important;
+  border-color:                        hsl(var(--oscm-primary)) !important;
   color:                               rgb(var(--oscm-white)) !important;
   &:hover {
-    background-color:                  rgb(var(--oscm-primary));
+    background-color:                  hsl(var(--oscm-primary));
     filter:                            brightness(0.8);
   }
   &:focus {
-    background-color:                  rgb(var(--oscm-primary));
+    background-color:                  hsl(var(--oscm-primary));
     color:                             rgb(var(--oscm-white)) !important;
-    box-shadow:                        rgba(var(--oscm-primary), 0.7);
+    box-shadow:                        hsla(var(--oscm-primary), 0.7);
   }
 }
 
 .btn-primary.disabled, .btn-secondary.disabled,
 .btn-primary:disabled, .btn-secondary:disabled {
-  background-color:                    rgba(var(--oscm-primary), 0.7);
-  border-color:                        rgba(var(--oscm-primary), 0.7);
+  background-color:                    hsla(var(--oscm-primary), 0.7);
+  border-color:                        hsla(var(--oscm-primary), 0.7);
 }
 
 .btn-outline-primary, .btn-outline-secondary {
-  color:                               rgb(var(--oscm-primary)) !important;
-  border-color:                        rgb(var(--oscm-primary)) !important;
+  color:                               hsl(var(--oscm-primary)) !important;
+  border-color:                        hsl(var(--oscm-primary)) !important;
   &:hover {
     color:                             rgb(var(--oscm-white)) !important;
-    background-color:                  rgb(var(--oscm-primary));
+    background-color:                  hsl(var(--oscm-primary));
   }
   &:focus {
-     background-color:                 rgb(var(--oscm-primary));
+     background-color:                 hsl(var(--oscm-primary));
      color:                            rgb(var(--oscm-white)) !important;
-     box-shadow:                       rgba(var(--oscm-primary), 0.7);
+     box-shadow:                       hsla(var(--oscm-primary), 0.7);
   }
 }
 
 .btn-outline-primary.active, .btn-outline-secondary.active,
 .btn-outline-primary:active, .btn-outline-secondary:active,
 .btn-outline-secondary:not(:disabled):not(.disabled).active {
-  background-color:                    rgb(var(--oscm-primary));
+  background-color:                    hsl(var(--oscm-primary));
   color:                               rgb(var(--oscm-white)) !important;
-  border-color:                        rgb(var(--oscm-primary));
+  border-color:                        hsl(var(--oscm-primary));
 }
 
 .btn-outline-primary.disabled, .btn-outline-secondary.disabled,
 .btn-outline-primary:disabled, .btn-outline-secondary:disabled {
-  color:                               rgba(var(--oscm-primary), 0.7);
-  border-color:                        rgba(var(--oscm-primary), 0.7);
+  color:                               hsla(var(--oscm-primary), 0.7);
+  border-color:                        hsla(var(--oscm-primary), 0.7);
 }
 
 .text-primary, .text-secondary {
-  color:                               rgb(var(--oscm-primary)) !important;
+  color:                               hsl(var(--oscm-primary)) !important;
 }
 
 .list-group-item-secondary {
   color:                               rgb(var(--oscm-text-color));
-  background-color:                    rgba(var(--oscm-primary), 0.8) !important;
+  background-color:                    hsla(var(--oscm-primary), 0.8) !important;
   &:hover {
-     background-color:                 rgb(var(--oscm-primary)) !important;
+     background-color:                 hsl(var(--oscm-primary)) !important;
      color:                            rgb(var(--oscm-white)) !important;
      filter:                           brightness(0.8);
   }
 }
 
 .list-group-item-secondary.active {
-  background-color:                    rgb(var(--oscm-primary)) !important;
+  background-color:                    hsl(var(--oscm-primary)) !important;
   color:                               rgb(var(--oscm-white)) !important;
   filter:                              brightness(0.9);
   &:hover {
-     background-color:                 rgb(var(--oscm-primary));
+     background-color:                 hsl(var(--oscm-primary));
      color:                            rgb(var(--oscm-white)) !important;
      filter:                           brightness(0.8);
   }
@@ -189,7 +189,7 @@ $darkened-color:                       rgb(var(--oscm-primary));
 }
 
 .border-secondary {
-  border-color:                        rgb(var(--oscm-primary)) !important;
+  border-color:                        hsl(var(--oscm-primary)) !important;
 }
 
 body {

--- a/oscm-portal/WebContent/marketplace/customBootstrap/scss/basic/_colors.scss
+++ b/oscm-portal/WebContent/marketplace/customBootstrap/scss/basic/_colors.scss
@@ -1,4 +1,7 @@
 :root {
+ --oscm-main-h:                        0;
+ --oscm-main-s:                        0%;
+ --oscm-main-l:                        93%;
  --oscm-main:                          238,238,238;
  --oscm-primary:                       7, 168, 93;
 
@@ -10,7 +13,8 @@
  --oscm-white:                         255, 255, 255;
  --oscm-black:                         0, 0, 0;
 
- --body-bg:                            rgba(var(--oscm-main), 0.1);
+ --osm-main:                           var(--oscm-main-h), var(--oscm-main-s), var(--oscm_main-l);
+ --body-bg:                            hsla(var(--oscm-main), 0.1);
  --oscm-text-color:                    rgb(var(--oscm-main-font-color));
  --oscm-bg-color:                      rgb(var(--oscm-main-input-color));
  --oscm-rv-color:                      rgb(var(--oscm-main-font-color));
@@ -18,26 +22,28 @@
  --oscm-dropdown-color:                rgb(var(--oscm-main-input-color));
  --oscm-input-color:                   rgb(var(--oscm-main-input-color));
 
- --oscm-main-color-100:                rgba(var(--oscm-main), 0.1);
- --oscm-main-color-200:                rgba(var(--oscm-main), 0.3);
- --oscm-main-color-300:                rgba(var(--oscm-main), 0.3);
- --oscm-main-color-400:                rgba(var(--oscm-main), 0.4);
- --oscm-main-color-500:                rgba(var(--oscm-main), 0.5);
- --oscm-main-color-600:                rgba(var(--oscm-main), 0.6);
- --oscm-main-color-700:                rgba(var(--oscm-main), 0.7);
- --oscm-main-color-800:                rgba(var(--oscm-main), 0.8);
- --oscm-main-color-900:                rgba(var(--oscm-main), 0.9);
+ --oscm-main-color-100:                hsla(var(--oscm-main), 0.1);
+ --oscm-main-color-200:                hsla(var(--oscm-main), 0.3);
+ --oscm-main-color-300:                hsla(var(--oscm-main), 0.3);
+ --oscm-main-color-400:                hsla(var(--oscm-main), 0.4);
+ --oscm-main-color-500:                hsla(var(--oscm-main), 0.5);
+ --oscm-main-color-600:                hsla(var(--oscm-main), 0.6);
+ --oscm-main-color-700:                hsla(var(--oscm-main), 0.7);
+ --oscm-main-color-800:                hsla(var(--oscm-main), 0.8);
+ --oscm-main-color-900:                hsla(var(--oscm-main), 0.9);
 
- --oscm-table-bg-color:                rgba(var(--oscm-main), 0.9);
+ --oscm-table-bg-color:                hsla(var(--oscm-main), 0.9);
  --oscm-table-border-color:            rgba(var(--oscm-black), 0.125);
- --oscm-table-hover-color:             rgba(var(--oscm-main), 0.3);
+ --oscm-table-hover-color:             hsla(var(--oscm-main), 0.3);
  --oscm-table-background-color:        rgb(var(--oscm-white));
- --oscm-table-row-odd-color:           rgba(var(--oscm-main), 0.1);
- --oscm-table-row-even-color:          rgb(var(--oscm-main));
+ --oscm-table-row-odd-color:           hsla(var(--oscm-main), 0.1);
+ --oscm-table-row-even-color:          hsl(var(--oscm-main);
 }
 
 :root[data-theme="dark"] {
- --oscm-main:                          38, 38, 38;
+ --oscm-main-h:                        0;
+ --oscm-main-s:                        0%;
+ --oscm-main-l:                        15%;
  --oscm-primary:                       7, 168, 93;
 
  --oscm-main-font-color:               248, 248, 248;
@@ -48,36 +54,39 @@
  --oscm-white:                         255, 255, 255;
  --oscm-black:                         0, 0, 0;
 
- --body-bg:                            rgba(var(--oscm-main), 0.8);
+ --osm-main:                           var(--oscm-main-h), var(--oscm-main-s), var(--oscm_main-l);
+ --body-bg:                            hsla(var(--oscm-main), 0.8);
  --oscm-text-color:                    rgb(var(--oscm-main-font-color));
- --oscm-bg-color:                      rgb(var(--oscm-main));
+ --oscm-bg-color:                      hsl(var(--oscm-main);
  --oscm-rv-color:                      rgb(var(--oscm-main-font-color));
  --oscm-border-color:                  rgba(var(--oscm-white), 0.3);
- --oscm-dropdown-color:                rgb(var(--oscm-main));
+ --oscm-dropdown-color:                hsl(var(--oscm-main);
  --oscm-input-color:                   rgb(var(--oscm-main-input-color));
 
- --oscm-main-color-100:                rgba(var(--oscm-main), 0.1);
- --oscm-main-color-200:                rgba(var(--oscm-main), 0.3);
- --oscm-main-color-300:                rgba(var(--oscm-main), 0.3);
- --oscm-main-color-400:                rgba(var(--oscm-main), 0.4);
- --oscm-main-color-500:                rgba(var(--oscm-main), 0.5);
- --oscm-main-color-600:                rgba(var(--oscm-main), 0.6);
- --oscm-main-color-700:                rgba(var(--oscm-main), 0.7);
- --oscm-main-color-800:                rgba(var(--oscm-main), 0.8);
- --oscm-main-color-900:                rgba(var(--oscm-main), 0.9);
+ --oscm-main-color-100:                hsla(var(--oscm-main), 0.1);
+ --oscm-main-color-200:                hsla(var(--oscm-main), 0.3);
+ --oscm-main-color-300:                hsla(var(--oscm-main), 0.3);
+ --oscm-main-color-400:                hsla(var(--oscm-main), 0.4);
+ --oscm-main-color-500:                hsla(var(--oscm-main), 0.5);
+ --oscm-main-color-600:                hsla(var(--oscm-main), 0.6);
+ --oscm-main-color-700:                hsla(var(--oscm-main), 0.7);
+ --oscm-main-color-800:                hsla(var(--oscm-main), 0.8);
+ --oscm-main-color-900:                hsla(var(--oscm-main), 0.9);
 
- --oscm-table-bg-color:                rgba(var(--oscm-main), 0.9);
- --oscm-table-border-color:            rgba(var(--oscm-main), 0.5);
- --oscm-table-hover-color:             rgba(var(--oscm-main), 0.9);
- --oscm-table-background-color:        rgba(var(--oscm-main), 0.1);
- --oscm-table-row-odd-color:           rgba(var(--oscm-main), 0.1);
- --oscm-table-row-even-color:          rgba(var(--oscm-main), 0.8);
+ --oscm-table-bg-color:                hsla(var(--oscm-main), 0.9);
+ --oscm-table-border-color:            hsla(var(--oscm-main), 0.5);
+ --oscm-table-hover-color:             hsla(var(--oscm-main), 0.9);
+ --oscm-table-background-color:        hsla(var(--oscm-main), 0.1);
+ --oscm-table-row-odd-color:           hsla(var(--oscm-main), 0.1);
+ --oscm-table-row-even-color:          hsla(var(--oscm-main), 0.8);
  --oscm-filter:                        brightness(1000%);
 }
 
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) {
-   --oscm-main:                        38, 38, 38;
+   --oscm-main-h:                      0;
+   --oscm-main-s:                      0%;
+   --oscm-main-l:                      15%;
    --oscm-primary:                     7, 168, 93;
 
    --oscm-main-font-color:             248, 248, 248;
@@ -88,30 +97,31 @@
    --oscm-white:                       255, 255, 255;
    --oscm-black:                       0, 0, 0;
 
-   --body-bg:                          rgba(var(--oscm-main), 0.8);
+   --osm-main:                         var(--oscm-main-h), var(--oscm-main-s), var(--oscm_main-l);
+   --body-bg:                          hsla(var(--oscm-main), 0.8);
    --oscm-text-color:                  rgb(var(--oscm-main-font-color));
-   --oscm-bg-color:                    rgb(var(--oscm-main));
+   --oscm-bg-color:                    hsl(var(--oscm-main);
    --oscm-rv-color:                    rgb(var(--oscm-main-font-color));
    --oscm-border-color:                rgba(var(--oscm-white), 0.3);
-   --oscm-dropdown-color:              rgb(var(--oscm-main));
+   --oscm-dropdown-color:              hsl(var(--oscm-main);
    --oscm-input-color:                 rgb(var(--oscm-main-input-color));
 
-   --oscm-main-color-100:              rgba(var(--oscm-main), 0.1);
-   --oscm-main-color-200:              rgba(var(--oscm-main), 0.3);
-   --oscm-main-color-300:              rgba(var(--oscm-main), 0.3);
-   --oscm-main-color-400:              rgba(var(--oscm-main), 0.4);
-   --oscm-main-color-500:              rgba(var(--oscm-main), 0.5);
-   --oscm-main-color-600:              rgba(var(--oscm-main), 0.6);
-   --oscm-main-color-700:              rgba(var(--oscm-main), 0.7);
-   --oscm-main-color-800:              rgba(var(--oscm-main), 0.8);
-   --oscm-main-color-900:              rgba(var(--oscm-main), 0.9);
+   --oscm-main-color-100:              hsla(var(--oscm-main), 0.1);
+   --oscm-main-color-200:              hsla(var(--oscm-main), 0.3);
+   --oscm-main-color-300:              hsla(var(--oscm-main), 0.3);
+   --oscm-main-color-400:              hsla(var(--oscm-main), 0.4);
+   --oscm-main-color-500:              hsla(var(--oscm-main), 0.5);
+   --oscm-main-color-600:              hsla(var(--oscm-main), 0.6);
+   --oscm-main-color-700:              hsla(var(--oscm-main), 0.7);
+   --oscm-main-color-800:              hsla(var(--oscm-main), 0.8);
+   --oscm-main-color-900:              hsla(var(--oscm-main), 0.9);
 
-   --oscm-table-bg-color:              rgba(var(--oscm-main), 0.9);
-   --oscm-table-border-color:          rgba(var(--oscm-main), 0.5);
-   --oscm-table-hover-color:           rgba(var(--oscm-main), 0.9);
-   --oscm-table-background-color:      rgba(var(--oscm-main), 0.1);
-   --oscm-table-row-odd-color:         rgba(var(--oscm-main), 0.1);
-   --oscm-table-row-even-color:        rgba(var(--oscm-main), 0.8);
+   --oscm-table-bg-color:              hsla(var(--oscm-main), 0.9);
+   --oscm-table-border-color:          hsla(var(--oscm-main), 0.5);
+   --oscm-table-hover-color:           hsla(var(--oscm-main), 0.9);
+   --oscm-table-background-color:      hsla(var(--oscm-main), 0.1);
+   --oscm-table-row-odd-color:         hsla(var(--oscm-main), 0.1);
+   --oscm-table-row-even-color:        hsla(var(--oscm-main), 0.8);
    --oscm-filter:                      brightness(1000%);
   }
 }

--- a/oscm-portal/WebContent/marketplace/customBootstrap/scss/basic/_colors.scss
+++ b/oscm-portal/WebContent/marketplace/customBootstrap/scss/basic/_colors.scss
@@ -1,9 +1,10 @@
 :root {
  --oscm-main-h:                        0;
- --oscm-main-s:                        0%;
+ --oscm-main-s:                        1%;
  --oscm-main-l:                        93%;
- --oscm-main:                          238,238,238;
- --oscm-primary:                       7, 168, 93;
+ --oscm-primary-h:                     152;
+ --oscm-primary-s:                     92%;
+ --oscm-primary-l:                     34%;
 
  --oscm-main-input-color:              248, 248, 248;
  --oscm-main-font-color:               33, 33, 33;
@@ -13,7 +14,8 @@
  --oscm-white:                         255, 255, 255;
  --oscm-black:                         0, 0, 0;
 
- --osm-main:                           var(--oscm-main-h), var(--oscm-main-s), var(--oscm_main-l);
+ --oscm-main:                          var(--oscm-main-h), var(--oscm-main-s), var(--oscm-main-l);
+ --oscm-primary:                       var(--oscm-primary-h), var(--oscm-primary-s), var(--oscm-primary-l);
  --body-bg:                            hsla(var(--oscm-main), 0.1);
  --oscm-text-color:                    rgb(var(--oscm-main-font-color));
  --oscm-bg-color:                      rgb(var(--oscm-main-input-color));
@@ -42,9 +44,11 @@
 
 :root[data-theme="dark"] {
  --oscm-main-h:                        0;
- --oscm-main-s:                        0%;
+ --oscm-main-s:                        1%;
  --oscm-main-l:                        15%;
- --oscm-primary:                       7, 168, 93;
+ --oscm-primary-h:                     152;
+ --oscm-primary-s:                     92%;
+ --oscm-primary-l:                     34%;
 
  --oscm-main-font-color:               248, 248, 248;
  --oscm-main-input-color:              33, 33, 33;
@@ -54,7 +58,8 @@
  --oscm-white:                         255, 255, 255;
  --oscm-black:                         0, 0, 0;
 
- --osm-main:                           var(--oscm-main-h), var(--oscm-main-s), var(--oscm_main-l);
+ --oscm-main:                          var(--oscm-main-h), var(--oscm-main-s), var(--oscm-main-l);
+ --oscm-primary:                       var(--oscm-primary-h), var(--oscm-primary-s), var(--oscm-primary-l);
  --body-bg:                            hsla(var(--oscm-main), 0.8);
  --oscm-text-color:                    rgb(var(--oscm-main-font-color));
  --oscm-bg-color:                      hsl(var(--oscm-main));
@@ -85,9 +90,11 @@
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) {
    --oscm-main-h:                      0;
-   --oscm-main-s:                      0%;
+   --oscm-main-s:                      1%;
    --oscm-main-l:                      15%;
-   --oscm-primary:                     7, 168, 93;
+   --oscm-primary-h:                   152;
+   --oscm-primary-s:                   92%;
+   --oscm-primary-l:                   34%;
 
    --oscm-main-font-color:             248, 248, 248;
    --oscm-main-input-color:            33, 33, 33;
@@ -97,7 +104,8 @@
    --oscm-white:                       255, 255, 255;
    --oscm-black:                       0, 0, 0;
 
-   --osm-main:                         var(--oscm-main-h), var(--oscm-main-s), var(--oscm_main-l);
+   --oscm-main:                        var(--oscm-main-h), var(--oscm-main-s), var(--oscm-main-l);
+   --oscm-primary:                     var(--oscm-primary-h), var(--oscm-primary-s), var(--oscm-primary-l);
    --body-bg:                          hsla(var(--oscm-main), 0.8);
    --oscm-text-color:                  rgb(var(--oscm-main-font-color));
    --oscm-bg-color:                    hsl(var(--oscm-main));

--- a/oscm-portal/WebContent/marketplace/customBootstrap/scss/basic/_colors.scss
+++ b/oscm-portal/WebContent/marketplace/customBootstrap/scss/basic/_colors.scss
@@ -37,7 +37,7 @@
  --oscm-table-hover-color:             hsla(var(--oscm-main), 0.3);
  --oscm-table-background-color:        rgb(var(--oscm-white));
  --oscm-table-row-odd-color:           hsla(var(--oscm-main), 0.1);
- --oscm-table-row-even-color:          hsl(var(--oscm-main);
+ --oscm-table-row-even-color:          hsl(var(--oscm-main));
 }
 
 :root[data-theme="dark"] {
@@ -57,10 +57,10 @@
  --osm-main:                           var(--oscm-main-h), var(--oscm-main-s), var(--oscm_main-l);
  --body-bg:                            hsla(var(--oscm-main), 0.8);
  --oscm-text-color:                    rgb(var(--oscm-main-font-color));
- --oscm-bg-color:                      hsl(var(--oscm-main);
+ --oscm-bg-color:                      hsl(var(--oscm-main));
  --oscm-rv-color:                      rgb(var(--oscm-main-font-color));
  --oscm-border-color:                  rgba(var(--oscm-white), 0.3);
- --oscm-dropdown-color:                hsl(var(--oscm-main);
+ --oscm-dropdown-color:                hsl(var(--oscm-main));
  --oscm-input-color:                   rgb(var(--oscm-main-input-color));
 
  --oscm-main-color-100:                hsla(var(--oscm-main), 0.1);
@@ -100,10 +100,10 @@
    --osm-main:                         var(--oscm-main-h), var(--oscm-main-s), var(--oscm_main-l);
    --body-bg:                          hsla(var(--oscm-main), 0.8);
    --oscm-text-color:                  rgb(var(--oscm-main-font-color));
-   --oscm-bg-color:                    hsl(var(--oscm-main);
+   --oscm-bg-color:                    hsl(var(--oscm-main));
    --oscm-rv-color:                    rgb(var(--oscm-main-font-color));
    --oscm-border-color:                rgba(var(--oscm-white), 0.3);
-   --oscm-dropdown-color:              hsl(var(--oscm-main);
+   --oscm-dropdown-color:              hsl(var(--oscm-main));
    --oscm-input-color:                 rgb(var(--oscm-main-input-color));
 
    --oscm-main-color-100:              hsla(var(--oscm-main), 0.1);

--- a/oscm-portal/WebContent/marketplace/customBootstrap/scss/components/_aside.scss
+++ b/oscm-portal/WebContent/marketplace/customBootstrap/scss/components/_aside.scss
@@ -41,7 +41,7 @@
 }
 
 .aside .menubox #menuArrow {
-  background: rgb(var(--oscm-main)) 0 0 no-repeat;
+  background: hsl(var(--oscm-main) 0 0 no-repeat;
   position: absolute;
   width: 11px;
   height: 21px;
@@ -52,7 +52,7 @@
 /* side menu elements wrapper */
 div.accd1span {
   width: 184px;
-  background: rgb(var(--oscm-main)) bottom left no-repeat;
+  background: hsl(var(--oscm-main) bottom left no-repeat;
   padding: 0 0 4px;
 }
 
@@ -60,7 +60,7 @@ div.accd1span {
 div.accdsection .heading {
   padding: 0 1px;
   min-height: 38px;
-  background: rgb(var(--oscm-main)) no-repeat left top;
+  background: hsl(var(--oscm-main) no-repeat left top;
 }
 
 div.accdsection h4#header, div.accdsection h4#menu0 {

--- a/oscm-portal/WebContent/marketplace/customBootstrap/scss/components/_aside.scss
+++ b/oscm-portal/WebContent/marketplace/customBootstrap/scss/components/_aside.scss
@@ -41,7 +41,7 @@
 }
 
 .aside .menubox #menuArrow {
-  background: hsl(var(--oscm-main) 0 0 no-repeat;
+  background: hsl(var(--oscm-main)) 0 0 no-repeat;
   position: absolute;
   width: 11px;
   height: 21px;
@@ -52,7 +52,7 @@
 /* side menu elements wrapper */
 div.accd1span {
   width: 184px;
-  background: hsl(var(--oscm-main) bottom left no-repeat;
+  background: hsl(var(--oscm-main)) bottom left no-repeat;
   padding: 0 0 4px;
 }
 
@@ -60,7 +60,7 @@ div.accd1span {
 div.accdsection .heading {
   padding: 0 1px;
   min-height: 38px;
-  background: hsl(var(--oscm-main) no-repeat left top;
+  background: hsl(var(--oscm-main)) no-repeat left top;
 }
 
 div.accdsection h4#header, div.accdsection h4#menu0 {

--- a/oscm-portal/WebContent/marketplace/customBootstrap/scss/components/_forms.scss
+++ b/oscm-portal/WebContent/marketplace/customBootstrap/scss/components/_forms.scss
@@ -15,7 +15,7 @@
 }
 
 .form-control:focus, .custom-select:focus, .btn:focus, .custom-file-input:focus, .page-link:focus {
-  border-color: rgb(var(--oscm-primary));
+  border-color: hsl(var(--oscm-primary));
   background-color: var(--oscm-input-color);
-  box-shadow: 0 0 0 0.2rem rgba(var(--oscm-primary), 0.5);
+  box-shadow: 0 0 0 0.2rem hsla(var(--oscm-primary), 0.5);
 }

--- a/oscm-portal/WebContent/marketplace/scss/_variables.scss
+++ b/oscm-portal/WebContent/marketplace/scss/_variables.scss
@@ -2,8 +2,8 @@
 
 @import "../customBootstrap/scss/basic/colors";
 
-$primary-color: rgb(var(--oscm-primary));
-$secondary-color: rgb(var(--oscm-primary));
+$primary-color: hsl(var(--oscm-primary));
+$secondary-color: hsl(var(--oscm-primary));
 $warning-color: red;
 $interior-color: rgb(var(--oscm-white));
 $main-color: hsl(var(--oscm-main));

--- a/oscm-portal/WebContent/marketplace/scss/_variables.scss
+++ b/oscm-portal/WebContent/marketplace/scss/_variables.scss
@@ -6,7 +6,7 @@ $primary-color: rgb(var(--oscm-primary));
 $secondary-color: rgb(var(--oscm-primary));
 $warning-color: red;
 $interior-color: rgb(var(--oscm-white));
-$main-color: hsl(var(--oscm-main);
+$main-color: hsl(var(--oscm-main));
 
 $dark-lighter: #343a40;
 $dark-lightest: #495057;

--- a/oscm-portal/WebContent/marketplace/scss/_variables.scss
+++ b/oscm-portal/WebContent/marketplace/scss/_variables.scss
@@ -6,7 +6,7 @@ $primary-color: rgb(var(--oscm-primary));
 $secondary-color: rgb(var(--oscm-primary));
 $warning-color: red;
 $interior-color: rgb(var(--oscm-white));
-$main-color: rgb(var(--oscm-main));
+$main-color: hsl(var(--oscm-main);
 
 $dark-lighter: #343a40;
 $dark-lightest: #495057;


### PR DESCRIPTION
**Changes in this Pull Request:**
- Change --oscm-main and --oscm-primary css variable for using hsl

Examples how to use:

Darken:
--oscm-main: var(--oscm-main-h),var(--oscm-main-s),calc(var(--oscm-main-l) - 15%);

Lighten:
--oscm-main: var(--oscm-main-h),var(--oscm-main-s),calc(var(--oscm-main-l) + 15%);

**Mandatory checks:**
- [x] Branch is up to date (latest changes were fetched from the upstream branch before creating this PR)
- [x] Changes were tested manually
- [ ] Java code changes are unit tested
- [ ] Webtests are successful

**To be checked by the reviewer:**
- [ ] Clean Java code and unit tested changes 
- [ ] UI customizablity is preserved: No hard-coded styling and URL references in JSF views 

**To be checked by the pull request owner:**
- [ ] .MASTER/job/BES_MASTER_IT/
- [ ] .MASTER/job/OSCM_WS_Tests_INTERNAL/
- [ ] .MASTER/job/OSCM_WS_Tests_OIDC/
- [ ] .MASTER/job/OSCM_Integration_Tests_INTERNAL/
- [ ] .MASTER/job/OSCM_Integration_Tests_OIDC/

**Cross repository and core changes:**
- [ ] Interdependent changes have been communicated to the team (if applicable)
- [ ] This pull request includes high risk modifications or core changes (e.g API, datamodel, authentication...). Mandatory reviewers: @goebell or @kowalczyka.

**OSCM Build References:**
- &lt;CI node number&gt;: &lt;tag&gt;, _example_: ci10:goebell

**Screenshot (if applicable):**
![image](https://user-images.githubusercontent.com/59691196/111307223-6afb5680-8659-11eb-98e2-dad9c327de20.png)
![image](https://user-images.githubusercontent.com/59691196/111307264-7c446300-8659-11eb-93d5-f5b481d58de7.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm/1214)
<!-- Reviewable:end -->
