### PR TITLE
Fix #1238 - fix bug in [key,value] color map.

### DIFF
--- a/oscm-portal/WebContent/WEB-INF/facelets/tags/marketplace/headerBootstrap.xhtml
+++ b/oscm-portal/WebContent/WEB-INF/facelets/tags/marketplace/headerBootstrap.xhtml
@@ -164,7 +164,7 @@
         document.documentElement.setAttribute(THEME_ATTR, mode);
 
          if (#{sessionScope.userDisplaySettings != null }) {
-           setColorSchema()
+           setColorSchema();
          }
       }
     };
@@ -177,20 +177,20 @@
     
     function setColorSchema() {
 
-      let colorMap = new Map()
-      colorMap.set('${sessionScope.userDisplaySettings.primaryColor}', '--oscm-primary')
-      colorMap.set('${sessionScope.userDisplaySettings.fontColor}', '--oscm-main-font-color')
-      colorMap.set('${sessionScope.userDisplaySettings.navbarColor}', '--oscm-navbar-color')
-      colorMap.set('${sessionScope.userDisplaySettings.navbarLinkColor}', '--oscm-navbar-links-color')
-      colorMap.set('${sessionScope.userDisplaySettings.inputColor}', '--oscm-main-input-color')
+      let colorMap = new Map();
+      colorMap.set('--oscm-primary', '${sessionScope.userDisplaySettings.primaryColor}');
+      colorMap.set('--oscm-main-font-color', '${sessionScope.userDisplaySettings.fontColor}');
+      colorMap.set('--oscm-navbar-color', '${sessionScope.userDisplaySettings.navbarColor}');
+      colorMap.set('--oscm-navbar-links-color', '${sessionScope.userDisplaySettings.navbarLinkColor}');
+      colorMap.set('--oscm-main-input-color', '${sessionScope.userDisplaySettings.inputColor}');
 
       for (let [key, value] of colorMap) {
-        if (key != null) {
-          var hsl = AdmUtils.hexToHSL(key);
+        if (value != null) {
+          var hsl = AdmUtils.hexToHSL(value);
 
-          document.documentElement.style.setProperty(value + '-h', hsl[0].toString());
-          document.documentElement.style.setProperty(value + '-s', hsl[1] + "%");
-          document.documentElement.style.setProperty(value + '-l', hsl[2] + "%");
+          document.documentElement.style.setProperty(key + '-h', hsl[0].toString());
+          document.documentElement.style.setProperty(key + '-s', hsl[1] + "%");
+          document.documentElement.style.setProperty(key + '-l', hsl[2] + "%");
         }
       }
     }


### PR DESCRIPTION
**Changes in this Pull Request:**
- The colorMap has been fixed, as it stored the color value as the "key" which is wrong. The variable name such as "--oscm-primary" etc. must be stored as the key of the colorMap.

**Mandatory checks:**
- [X] Branch is up to date (latest changes were fetched from the upstream branch before creating this PR)
- [X] Changes were tested manually
- [ ] Java code changes are unit tested
- [ ] Webtests are successful

**To be checked by the reviewer:**
- [ ] Clean Java code and unit tested changes 
- [X] UI customizablity is preserved: No hard-coded styling and URL references in JSF views 

**To be checked by the pull request owner:**
- [ ] .MASTER/job/BES_MASTER_IT/
- [] .MASTER/job/OSCM_WS_Tests_INTERNAL/
- [ ] .MASTER/job/OSCM_WS_Tests_OIDC/
- [X] .MASTER/job/OSCM_Integration_Tests_INTERNAL/
- [ ] .MASTER/job/OSCM_Integration_Tests_OIDC/

**Cross repository and core changes:**
- [ ] Interdependent changes have been communicated to the team (if applicable)
- [ ] This pull request includes high risk modifications or core changes (e.g API, datamodel, authentication...). Mandatory reviewers: @goebell or @kowalczyka.

**OSCM Build References:**
- est6
**Screenshot (if applicable):**
![Screenshot_2021-04-21 Marketplace](https://user-images.githubusercontent.com/49904723/115567575-b1c51780-a2bb-11eb-839b-a12b2132fba4.png)

![Screenshot_2021-04-21 Marketplace(1)](https://user-images.githubusercontent.com/49904723/115567604-bb4e7f80-a2bb-11eb-8284-8b9c6a8a1a7f.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm/1244)
<!-- Reviewable:end -->
