### PR TITLE
Task#1243 service card layout broken

### DIFF
--- a/oscm-portal/WebContent/marketplace/customBootstrap/scss/_commonStyles.scss
+++ b/oscm-portal/WebContent/marketplace/customBootstrap/scss/_commonStyles.scss
@@ -33,7 +33,7 @@ button, input,textarea {
 
 // Grid layout for service card.
 .gridLayoutForCard {
-  @include make-col-ready;
+  
   @include media-breakpoint-up(sm) {
     @include make-col(12);
   }

--- a/oscm-portal/WebContent/marketplace/customBootstrap/scss/_commonStyles.scss
+++ b/oscm-portal/WebContent/marketplace/customBootstrap/scss/_commonStyles.scss
@@ -2,9 +2,9 @@
 /* import only the necessary Bootstrap files */
 @import "../../bootstrap/scss/functions"; 
 @import "../../bootstrap/scss/variables";
-
 @import "../../bootstrap/scss/mixins/grid";
 
+$enable-grid-classes: false;
 html, body {
   max-width: 100%;
   overflow-x: hidden;

--- a/oscm-portal/WebContent/marketplace/customBootstrap/scss/_customVariables.scss
+++ b/oscm-portal/WebContent/marketplace/customBootstrap/scss/_customVariables.scss
@@ -1,5 +1,6 @@
 @import "./basic/colors";
 
+$enable-grid-classes: false;
 $body-color:                           hsl(var(--oscm-main-font-color));
 $bg-body:                              var(--oscm-bg-color);
 $bg-light:                             var(--oscm-bg-color);

--- a/oscm-portal/WebContent/marketplace/customBootstrap/scss/_customVariables.scss
+++ b/oscm-portal/WebContent/marketplace/customBootstrap/scss/_customVariables.scss
@@ -1,6 +1,5 @@
 @import "./basic/colors";
 
-$enable-grid-classes: false;
 $body-color:                           hsl(var(--oscm-main-font-color));
 $bg-body:                              var(--oscm-bg-color);
 $bg-light:                             var(--oscm-bg-color);


### PR DESCRIPTION
**Changes in this Pull Request:**
- Set `$enable-grid-classes` to false
- Delete `make-col-ready` mixin from .gridLayoutForCard.

** Explanation**
- In Bootstrap 5.0 Beta 3 (not in previous v4.3.1), Bootstrap creates the default grid classes as follows: in class _grid a row is created by using the `make-col-ready` mixin. So an entry is created: `.row > *` with `width: 100%` which breaks our service grid layout as it overwrites the widths of `33,33 %`, `50%` and so on of the columns at the different breakpoints.

- this default behavior is enabled by a boolean: $enable-grid-classes. It is not necessary to create these clases, as we create our own columns with the `.gridLayoutForCard` class and `make-col` mixins in _commonStyles.

**Mandatory checks:**
- [X] Branch is up to date (latest changes were fetched from the upstream branch before creating this PR)
- [X] Changes were tested manually
- [ ] Java code changes are unit tested
- [ ] Webtests are successful

**To be checked by the reviewer:**
- [ ] Clean Java code and unit tested changes 
- [X] UI customizablity is preserved: No hard-coded styling and URL references in JSF views 

**To be checked by the pull request owner:**
- [ ] .MASTER/job/BES_MASTER_IT/
- [ ] .MASTER/job/OSCM_WS_Tests_INTERNAL/
- [ ] .MASTER/job/OSCM_WS_Tests_OIDC/
- [] .MASTER/job/OSCM_Integration_Tests_INTERNAL/
- [ ] .MASTER/job/OSCM_Integration_Tests_OIDC/

**Cross repository and core changes:**
- [ ] Interdependent changes have been communicated to the team (if applicable)
- [ ] This pull request includes high risk modifications or core changes (e.g API, datamodel, authentication...). Mandatory reviewers: @goebell or @kowalczyka.

**OSCM Build References:**
- est6

**Screenshot (if applicable):**
![Screenshot_2021-04-27 Marketplace](https://user-images.githubusercontent.com/49904723/116272527-44b0f680-a781-11eb-93cd-b4a090e21af1.png)

![Screenshot_2021-04-27 Marketplace(1)](https://user-images.githubusercontent.com/49904723/116272402-2945eb80-a781-11eb-9198-f539a5baaf90.png)

![Screenshot_2021-04-27 Marketplace(2)](https://user-images.githubusercontent.com/49904723/116272395-26e39180-a781-11eb-95c2-4683392261c7.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm/1248)
<!-- Reviewable:end -->
