### PR TITLE
Task#1236 active list groups light

### DIFF
--- a/oscm-portal/WebContent/marketplace/customBootstrap/scss/_customVariables.scss
+++ b/oscm-portal/WebContent/marketplace/customBootstrap/scss/_customVariables.scss
@@ -84,7 +84,7 @@ $darkened-color:                       hsl(var(--oscm-primary));
  }
 
 a.text-secondary:hover, a.text-secondary:focus, a.text-primary:hover, a.text-primary:focus {
-  color:                              hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l) - -5%)) !important;
+  color:                              hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l) - 5%)) !important;
 }
 
 .btn-primary, .btn-secondary {
@@ -92,7 +92,7 @@ a.text-secondary:hover, a.text-secondary:focus, a.text-primary:hover, a.text-pri
   border-color:                        hsl(var(--oscm-primary)) !important;
   color:                               rgb(var(--oscm-white)) !important;
   &:hover {
-    background-color:                  hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l) - -5%)) !important;
+    background-color:                  hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l) - 5%)) !important;
     box-shadow:                        0px 0px 2px 4px hsla(var(--oscm-primary), 0.24);
   }
   &:focus {
@@ -113,7 +113,7 @@ a.text-secondary:hover, a.text-secondary:focus, a.text-primary:hover, a.text-pri
   border-color:                        hsl(var(--oscm-primary)) !important;
   &:hover {
     color:                             rgb(var(--oscm-white)) !important;
-    background-color:                  hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l) - -5%)) !important;
+    background-color:                  hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l) - 5%)) !important;
     box-shadow:                        0px 0px 2px 4px hsla(var(--oscm-primary), 0.24);
   }
   &:focus {
@@ -143,18 +143,18 @@ a.text-secondary:hover, a.text-secondary:focus, a.text-primary:hover, a.text-pri
 
 .list-group-item-secondary {
   color:                               hsl(var(--oscm-main-font-color));
-  background-color:                    hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l) - 5%)) !important;
+  background-color:                    hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l) - -7%)) !important;
   &:hover {
-     background-color:                 hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l) - -10%)) !important;
+     background-color:                 hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l))) !important;
      color:                            rgb(var(--oscm-white)) !important;
   }
 }
 
 .list-group-item-secondary.active {
-  background-color:                    hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l) - -5%)) !important;
+  background-color:                    hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l))) !important;
   color:                               rgb(var(--oscm-white)) !important;
   &:hover {
-     background-color:                 hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l) - -10%)) !important;
+     background-color:                 hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l))) !important;
      color:                            rgb(var(--oscm-white)) !important;
   }
 }

--- a/oscm-portal/WebContent/marketplace/customBootstrap/scss/_customVariables.scss
+++ b/oscm-portal/WebContent/marketplace/customBootstrap/scss/_customVariables.scss
@@ -143,7 +143,7 @@ a.text-secondary:hover, a.text-secondary:focus, a.text-primary:hover, a.text-pri
 
 .list-group-item-secondary {
   color:                               hsl(var(--oscm-main-font-color));
-  background-color:                    hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l) - -7%)) !important;
+  background-color:                    hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l) - -10%)) !important;
   &:hover {
      background-color:                 hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l))) !important;
      color:                            rgb(var(--oscm-white)) !important;

--- a/oscm-portal/WebContent/marketplace/customBootstrap/scss/_customVariables.scss
+++ b/oscm-portal/WebContent/marketplace/customBootstrap/scss/_customVariables.scss
@@ -145,16 +145,16 @@ a.text-secondary:hover, a.text-secondary:focus, a.text-primary:hover, a.text-pri
   color:                               hsl(var(--oscm-main-font-color));
   background-color:                    hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l) - -10%)) !important;
   &:hover {
-     background-color:                 hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l))) !important;
+     background-color:                 hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l) - 5%)) !important;
      color:                            rgb(var(--oscm-white)) !important;
   }
 }
 
 .list-group-item-secondary.active {
-  background-color:                    hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l))) !important;
+  background-color:                    hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l) - 5%)) !important;
   color:                               rgb(var(--oscm-white)) !important;
   &:hover {
-     background-color:                 hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l))) !important;
+     background-color:                 hsla(var(--oscm-primary-h), var(--oscm-primary-s), calc(var(--oscm-primary-l) - 5%)) !important;
      color:                            rgb(var(--oscm-white)) !important;
   }
 }


### PR DESCRIPTION
**Changes in this Pull Request:**
- "primary color" shade for active list-group and lighter shades for non-active list-groups.
- primary button on hover is 5% darker.

**Mandatory checks:**
- [X] Branch is up to date (latest changes were fetched from the upstream branch before creating this PR)
- [X] Changes were tested manually
- [ ] Java code changes are unit tested
- [ ] Webtests are successful

**To be checked by the reviewer:**
- [ ] Clean Java code and unit tested changes 
- [X] UI customizablity is preserved: No hard-coded styling and URL references in JSF views 

**To be checked by the pull request owner:**
- [ ] .MASTER/job/BES_MASTER_IT/
- [ ] .MASTER/job/OSCM_WS_Tests_INTERNAL/
- [ ] .MASTER/job/OSCM_WS_Tests_OIDC/
- [ ] .MASTER/job/OSCM_Integration_Tests_INTERNAL/
- [ ] .MASTER/job/OSCM_Integration_Tests_OIDC/

**Cross repository and core changes:**
- [ ] Interdependent changes have been communicated to the team (if applicable)
- [ ] This pull request includes high risk modifications or core changes (e.g API, datamodel, authentication...). Mandatory reviewers: @goebell or @kowalczyka.

**OSCM Build References:**
- est6 (default branding)

**Screenshot (if applicable):**
![Screenshot_2021-05-06 Marketplace(2)](https://user-images.githubusercontent.com/49904723/117336313-5a6a9e00-ae9c-11eb-9b35-ac2d1bb2fa8b.png)

![Screenshot_2021-05-06 Marketplace](https://user-images.githubusercontent.com/49904723/117336318-5c346180-ae9c-11eb-9501-94e29f68ab69.png)

![Screenshot_2021-05-06 Marketplace(4)](https://user-images.githubusercontent.com/49904723/117336442-7ec67a80-ae9c-11eb-9206-7405ab801d00.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm/1251)
<!-- Reviewable:end -->
