### PR TITLE
Task#1246 correct file import style

### DIFF
--- a/oscm-portal/WebContent/WEB-INF/facelets/tags/fileUploadBootstrap.xhtml
+++ b/oscm-portal/WebContent/WEB-INF/facelets/tags/fileUploadBootstrap.xhtml
@@ -7,13 +7,13 @@
  <ui:param name="key" value="#{empty label ? 'common.filename' : label}"/>
  <adm:outputLabel value="#{msg[key]}" rendered="#{(empty rendered or rendered) and (empty labels)}" required="true"/>
 
- <div class="form-control p-1 me-1">
+ <div class="form-control p-0 me-1">
   <h:inputFile id="file" label="#{msg['common.filename']}" disabled="#{disabled}"
                onchange="jQuery('.form-label').text(this.value);setDirty(true)"
                value="#{value}" size="48" styleClass="fileChooser d-none"
                required="#{(empty required or required) and (empty rendered or rendered)}"
                rendered="#{empty rendered or rendered}" requiredMessage="#{msg['error.upload.fileNotNullNorEmpty']}"/>
-  <h:outputLabel id="inputFile" class="form-label btn text-start w-100 h-100 p-0 m-0" for="file"/>
+  <h:outputLabel id="inputFile" class="form-label btn text-end w-100 h-100 p-0 m-0" for="file"/>
  </div>
  <adm:message for="file" rendered="#{(empty rendered or rendered) and (empty labels)}"/>
 </ui:composition>

--- a/oscm-portal/WebContent/WEB-INF/facelets/tags/fileUploadBootstrap.xhtml
+++ b/oscm-portal/WebContent/WEB-INF/facelets/tags/fileUploadBootstrap.xhtml
@@ -13,7 +13,7 @@
                value="#{value}" size="48" styleClass="fileChooser d-none"
                required="#{(empty required or required) and (empty rendered or rendered)}"
                rendered="#{empty rendered or rendered}" requiredMessage="#{msg['error.upload.fileNotNullNorEmpty']}"/>
-  <h:outputLabel id="inputFile" class="form-label btn text-end w-100 h-100 p-0 m-0" for="file"/>
+  <h:outputLabel id="inputFile" class="form-label btn text-start w-100 h-100 p-0 m-0" for="file"/>
  </div>
  <adm:message for="file" rendered="#{(empty rendered or rendered) and (empty labels)}"/>
 </ui:composition>

--- a/oscm-portal/WebContent/marketplace/customBootstrap/scss/basic/_mixins.scss
+++ b/oscm-portal/WebContent/marketplace/customBootstrap/scss/basic/_mixins.scss
@@ -12,7 +12,6 @@
   transition: $args;
 }
 
-
 @mixin font-face($font-name, $file-name, $weight: normal, $style: normal) {
   @font-face {
     font-family: quote($font-name);

--- a/oscm-portal/WebContent/marketplace/customBootstrap/scss/components/_forms.scss
+++ b/oscm-portal/WebContent/marketplace/customBootstrap/scss/components/_forms.scss
@@ -24,3 +24,21 @@ input {
   background-color: hsl(var(--oscm-main-input-color));
   color: hsl(var(--oscm-main-font-color))!important;
 }
+
+.form-label:after {
+  content: "\f093";
+  font-family: FontAwesome;
+  cursor: pointer;
+  color: hsl(var(--oscm-primary));
+  border-color: hsl(var(--oscm-primary));
+  border: 1px solid;
+  background-color: hsl(var(--oscm-main)); 
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  padding: 0.375rem 0.75rem !important;
+  height: calc(1.5em + 0.77rem);
+  margin-right: -1px;
+  margin-top: -1px;
+}

--- a/oscm-portal/WebContent/marketplace/scss/components/_buttons.scss
+++ b/oscm-portal/WebContent/marketplace/scss/components/_buttons.scss
@@ -259,11 +259,3 @@ span.upload .option {
   background-position: right top;
   margin-left: 4px; }
 
-.form-label:after {
-  content: "\f093";
-  font-family: FontAwesome;
-  cursor: pointer;
-  color: hsl(var(--oscm-primary));
-  border-color: hsl(var(--oscm-primary));
-  border: 1px solid;
-  background-color: hsl(var(--oscm-main)); }


### PR DESCRIPTION
**Changes in this Pull Request:**
- Fixed file import button style as shown in below Screenshot
- Reason for the misplacement was the upgrade to Bootstrap v5.0, becuase some styles for the `.form-label:after` were removed from the Bootstrap source files.

**Mandatory checks:**
- [X] Branch is up to date (latest changes were fetched from the upstream branch before creating this PR)
- [X] Changes were tested manually
- [ ] Java code changes are unit tested
- [X] Webtests are successful

**To be checked by the reviewer:**
- [ ] Clean Java code and unit tested changes 
- [X] UI customizablity is preserved: No hard-coded styling and URL references in JSF views 

**To be checked by the pull request owner:**
- [ ] .MASTER/job/BES_MASTER_IT/
- [ ] .MASTER/job/OSCM_WS_Tests_INTERNAL/
- [ ] .MASTER/job/OSCM_WS_Tests_OIDC/
- [ ] .MASTER/job/OSCM_Integration_Tests_INTERNAL/
- [ ] .MASTER/job/OSCM_Integration_Tests_OIDC/

**Cross repository and core changes:**
- [ ] Interdependent changes have been communicated to the team (if applicable)
- [ ] This pull request includes high risk modifications or core changes (e.g API, datamodel, authentication...). Mandatory reviewers: @goebell or @kowalczyka.

**OSCM Build References:**
- est6

**Screenshot (if applicable):**
![Screenshot 2021-06-09 at 13-50-18 Marketplace](https://user-images.githubusercontent.com/49904723/121359462-cc1e8780-c933-11eb-9496-36320760caef.png)

![Screenshot 2021-06-09 at 13-49-52 Marketplace](https://user-images.githubusercontent.com/49904723/121359469-cde84b00-c933-11eb-9446-b89a839dcf13.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/servicecatalog/oscm/1260)
<!-- Reviewable:end -->
